### PR TITLE
fix(middleware): Enforce encoding_name

### DIFF
--- a/compression_middleware/middleware.py
+++ b/compression_middleware/middleware.py
@@ -67,8 +67,12 @@ def encoding_name(s):
         s, q = s.split(";")
         if "=" in q:
             _, q = q.split("=")
-            if float(q) == 0.0:
-                return None
+            try:
+                q = float(q)
+                if q == 0.0:
+                    return None
+            except ValueError:
+                pass
     return s.strip()
 
 


### PR DESCRIPTION
Hello,

An attacker/botnet started to crawl our site some days ago with random requests trying to find weak spots or leakages. The crawler is badly configured to send an invalid `HTTP_ACCEPT_ENCODING` header and  `django-compression-middleware` breaks raising a 500 error like this:

> Internal Server Error: /upload.zip
> 
> ValueError at /upload.zip
> could not convert string to float: 'utf-8'
> 
> Request Method: HEAD
> Request URL: https://XXXXXXX/upload.zip
> Django Version: 4.1.7
> Python Executable: /usr/bin/uwsgi-core
> Python Version: 3.9.16
> 
> (...)
> 
> META:
> CONTENT_LENGTH = ''
> CONTENT_TYPE = ''
> HTTP_ACCEPT = 'text/plain,*/*; charset=utf-8'
> HTTP_ACCEPT_ENCODING = 'text/plain,*/*; charset=utf-8'

> 
> Traceback (most recent call last):
>   File "XXX/site-packages/compression_middleware/middleware.py", line 106, in process_response
>     encoding, compress_func, stream_func = compressor(ae)
>   File "XXX/site-packages/compression_middleware/middleware.py", line 78, in compressor
>     client_encodings = set(encoding_name(e) for e in accept_encoding.split(","))
>   File "XXX/site-packages/compression_middleware/middleware.py", line 78, in <genexpr>
>     client_encodings = set(encoding_name(e) for e in accept_encoding.split(","))
>   File "XXX/site-packages/compression_middleware/middleware.py", line 70, in encoding_name
>     if float(q) == 0.0:
> 
> Exception Type: ValueError at /upload.zip
> Exception Value: could not convert string to float: 'utf-8'

This PR solves the 500 error by try-catching the float casting and adds a test to prove it works. The same test breaks without the change done on `compression_middleware/middleware.py`.

Thanks!